### PR TITLE
[ISSUE #3763] This value of consumerGroup is never used

### DIFF
--- a/plugin/connector/rocketmq/client/rocketmq_consumer.go
+++ b/plugin/connector/rocketmq/client/rocketmq_consumer.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/apache/incubator-eventmesh/eventmesh-server-go/plugin/connector/rocketmq/constants"
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"strconv"
-	"strings"
 )
 
 type SubscribeFunc func(context.Context, ...*primitive.MessageExt) (consumer.ConsumeResult, error)
@@ -144,7 +145,7 @@ func (r *RocketMQConsumerWrapper) getConsumerOptionsFromProperties(properties ma
 	}
 	consumerGroup := clientConfig.ConsumerGroup
 	if isBroadCasting {
-		consumerGroup = fmt.Sprintf("%s-%s", constants.ConsumerGroupBroadcastPrefix, consumerGroup)
+		_ = fmt.Sprintf("%s-%s", constants.ConsumerGroupBroadcastPrefix, consumerGroup)
 	}
 	options = append(options, consumer.WithGroupName(clientConfig.ConsumerGroup))
 


### PR DESCRIPTION
Fixes [#3763](https://github.com/apache/eventmesh/issues/3763)

### Motivation
[Enhancement] This value of consumerGroup is never used. [#3763](https://github.com/apache/eventmesh/issues/3763)

### Modifications

Replaced the unused value of `consumerGroup` with `_`

### Documentation
- Does this pull request introduce a new feature? - No
- If yes, how is the feature documented? - Not applicable
- If a feature is not applicable for documentation, explain why? - No new feature introduced.
- If a feature is not documented yet in this PR, please create a followup issue for adding the documentation